### PR TITLE
Move local dev settings to .local.env

### DIFF
--- a/.local.env
+++ b/.local.env
@@ -9,3 +9,10 @@ TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_MESSAGING_SERVICE_SID=
 TWILIO_MESSAGE_STATUS_CALLBACK=
+
+# Settings to use fixutre RSA Keys
+# The path is derived from the Dockerfile working directory
+AUTH_PUBLIC_KEY_PATH=/usr/src/app/__fixtures__/public-key.pem
+AUTH_PRIVATE_KEY_PATH=/usr/src/app/__fixtures__/private-key.pem
+AUTH_ACCESS_TOKEN_AUDIENCE=dev.gatekeeper.io
+AUTH_ACCESS_TOKEN_ISSUER=https://dev.gatekeeper.io

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,11 +4,5 @@ services:
   server:
     volumes:
       - ".:/usr/src/app"
-    # Setup for running using __fixture__ keys
-    environment:
-      - "AUTH_PUBLIC_KEY_PATH=/usr/src/app/__fixtures__/public-key.pem"
-      - "AUTH_PRIVATE_KEY_PATH=/usr/src/app/__fixtures__/private-key.pem"
-      - "AUTH_ACCESS_TOKEN_AUDIENCE=staging.molly.ml"
-      - "AUTH_ACCESS_TOKEN_ISSUER=https://staging.mollyapi.ml"
     env_file:
       - .local.env


### PR DESCRIPTION
#### This PR
- Moves settings that enable easy local development (e.g. using the test keys in `__fixtures__`) to `.local.env` instead of the compose override. This makes the compose files less of a variant.