### PR TITLE
Add Docker self-host info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,59 @@
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-Gatekeeper is lightweight JWT-based authentication server for passwordless SMS phone
-verification.
+Gatekeeper is open source, lightweight JWT-based authentication server for passwordless
+SMS phone verification.
 Users signup to your service by entering an SMS code, generating an access token which
 can be verified by your application without requiring database lookups.
 Persistent sessions are supported with refresh tokens.
 
-#### Contributing
+### Self Hosting
+
+Gatekeeper is a Dockerized Python Django app.
+
+The easiest way to get started is to pull the Gatekeeper image from `benmoose/gatekeeper`. 
+Alternatively, you might build your own image from this repository, or run the app directly
+on a server without Docker at all.
+
+#### Gatekeeper Docker Image
+
+The official Gatekeeper image lives on Docker Hub.
+
+```bash
+docker pull benmoose/gatekeeper
+```
+
+The quickest way to get started is to pull that image and expose it to the internet from
+behind a web server (e.g. Nginx).
+
+##### Configuring Gatekeeper with Nginx
+
+The Gatekeeper image listens for incoming requests at unix socket `/var/tmp/shared-mount/gunicorn.sock`.
+To run Gatekeeper with Nginx, you'll need to tell Nginx to send requests to that unix socket.
+
+To do that, you'll need something like this in your Nginx config.
+
+```
+http {
+    upstream gatekeeper {
+        server unix:/var/tmp/shared-mount/gunicorn.sock;
+    }
+    
+    server {
+        location / {
+            proxy_pass  http://gatekeeper;
+        }
+    }
+}
+```
+
+There's a full reference nginx.conf at [`operations/nginx/nginx.conf`](/operations/nginx/nginx.conf).
+
+When configuring your docker containers, ensure that `/var/tmp/shared-mount/gunicorn.sock`
+is a shared volume so both your Gatekeeper and Nginx containers can communicate.
+(See [docker-compose.yml](docker-compose.yml) for an example.)
+
+### Contributing
 
 Docker is recommended for local development.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     volumes:
       - "shared-mount:/var/tmp/shared-mount"
     environment:
-      - "DJANGO_SETTINGS_MODULE=django_conf.settings"
       - "ENVIRONMENT=development"
       - "DB_NAME=postgres"
       - "DB_USER=postgres"

--- a/gatekeeper/django_conf/settings.py
+++ b/gatekeeper/django_conf/settings.py
@@ -70,7 +70,10 @@ for setting_name in SETTINGS_FROM_ENVIRONMENT:
 
 for setting_name in SETTINGS_FROM_ENVIRONMENT:
     if vars()[setting_name] is None:
-        logger.warning(f"Missing setting {setting_name}: set with environment variable")
+        logger.warning(
+            f"{setting_name} has not been configured, "
+            f"you can set it with an environment variable"
+        )
 
 
 if ENVIRONMENT not in ALLOWED_ENVIRONMENTS:

--- a/gatekeeper/django_conf/wsgi.py
+++ b/gatekeeper/django_conf/wsgi.py
@@ -7,8 +7,6 @@ For more information on this file, see
 https://docs.djangoproject.com/en/2.2/howto/deployment/wsgi/
 """
 
-import os
-
 from django.core.wsgi import get_wsgi_application
 
 application = get_wsgi_application()

--- a/operations/django/Dockerfile
+++ b/operations/django/Dockerfile
@@ -8,12 +8,12 @@ RUN pip wheel -r ./requirements/requirements.test.txt
 
 FROM python:3.7-slim
 ENV PYTHONUNBUFFERED 1
+ENV DJANGO_SETTINGS_MODULE django_conf.settings
 
 COPY --from=builder /wheels /wheels
 
-RUN pip install -r /wheels/requirements/requirements.test.txt -f /wheels \
-    && rm -rf /wheels \
-    && rm -rf /root/.cache/pip/*
+RUN pip install --no-cache-dir -r \
+    /wheels/requirements/requirements.test.txt -f /wheels
 
 WORKDIR /usr/src/app
 COPY . .


### PR DESCRIPTION
#### This PR:
- Adds info on using the gatekeeper docker image
- Removes need to manually specify `DJANGO_SETTINGS_MODULE` when running from Docker image (the env-var is now baked into the image)
- Adds Docker build badge ✨

For now, it only has details on using the `benmoose/gatekeeper` image, not on building custom images or using without Docker.